### PR TITLE
fix: update getTransactions function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
   FloatTransaction,
   FixTransaction,
   Filter,
-  FloatExchangeAmount
+  FloatExchangeAmount,
+  TransactionDetail
 } from './types';
 
 export class Changelly {
@@ -148,7 +149,7 @@ export class Changelly {
   /**
    * Returns an array of all transactions or a filtered list of transactions
    */
-  async getTransactions(filter: Filter) {
+  async getTransactions(filter: Filter): Promise<Array<TransactionDetail>> {
     return await this.postAPI('getTransactions', filter);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,42 +107,33 @@ export type FixTransaction = {
 };
 
 export type Filter = {
+  id?: string;
   currency?: string;
-  address?: string;
-  extraId?: string;
+  payoutAddress?: string;
   limit?: number;
   offset?: number;
 };
 
 export type TransactionDetail = {
   id: string;
-  createdAt: number;
-  type: string;
-  moneyReceived: number;
-  moneySent: number;
-  rate: string;
-  payinConfirmations: string;
   status: string;
   currencyFrom: string;
   currencyTo: string;
+  payinHash: string;
+  payoutHash: string;
+  refundHash: string | null;
   payinAddress: string;
-  payinExtraId: null | string;
-  payinExtraIdName: null | string;
-  payinHash: null | string;
-  amountExpectedFrom: string;
+  payinExtraId: string | null;
   payoutAddress: string;
-  payoutExtraId: null | string;
-  payoutExtraIdName: null | string;
-  payoutHash: null | string;
-  refundHash: null | string;
+  payoutExtraId: string | null;
+  amountExpectedFrom: string;
+  amountExpectedTo: string;
   amountFrom: string;
   amountTo: string;
-  amountExpectedTo: string;
+  refundReason: string | null;
   networkFee: string;
-  changellyFee: string;
-  apiExtraFee: string;
-  totalFee: null | string;
-  fiatProviderId: null | string;
-  fiatProvider: null | string;
-  fiatProviderRedirect: null | string;
+  createdAt: number;
+  duration: number;
+  transactionType: "fix" | "float";
+  payinSenders: string[];
 };


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR updates the `getTransactions` function to improve the type safety and clarity of transaction data. It modifies the function's return type to explicitly indicate a promise of an array of `TransactionDetail` objects.

**Key Changes**
- Modified `getTransactions` function signature to return `Promise<Array<TransactionDetail>>`.
- Added the `TransactionDetail` type, which provides a more structured and detailed representation of a transaction, including fields like `payinHash`, `payoutHash`, `createdAt`, `duration`, and more.
- Updated the `Filter` type to include `id` and `payoutAddress` and removed deprecated fields.

**Recommendations**
Ready to merge after verifying the updated type definitions and ensuring the `getTransactions` function correctly returns data in the new `TransactionDetail` format.  Test cases should be updated to reflect the new type.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>